### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.target
+target
+**/.DS_Store
+**/*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+FROM rust:1.82-slim AS builder
+WORKDIR /app
+
+# Install build dependencies for OpenSSL / libpq bindings
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends pkg-config libssl-dev libpq-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Cache dependencies
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY README.md .
+RUN cargo build --release --bin database-replicator
+
+FROM debian:bookworm-slim
+LABEL org.opencontainers.image.title="database-replicator" \
+      org.opencontainers.image.description="Seren database replicator CLI" \
+      org.opencontainers.image.source="https://github.com/serenorg/database-replicator"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates libssl3 libpq5 && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -m replicator
+
+COPY --from=builder /app/target/release/database-replicator /usr/local/bin/database-replicator
+USER replicator
+ENTRYPOINT ["database-replicator"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -231,6 +231,31 @@ cargo build --release
 
 The binary will be available at `target/release/database-replicator`.
 
+### Docker Image
+
+Build a container image with the latest source:
+
+```bash
+docker build -t serenorg/database-replicator:latest .
+```
+
+Run the CLI inside the container (pass connection strings via arguments or environment variables):
+
+```bash
+docker run --rm -it \
+  serenorg/database-replicator:latest \
+  validate --source "postgresql://user:pass@source/db" --target "postgresql://user:pass@target/db"
+```
+
+Mount local config files if needed:
+
+```bash
+docker run --rm -it \
+  -v "$PWD:/work" \
+  serenorg/database-replicator:latest \
+  init --source @/work/source.txt --target @/work/target.txt
+```
+
 ### Prerequisites
 
 - **PostgreSQL client tools** (pg_dump, pg_dumpall, psql) - Required for all database types


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for packaging the CLI with OpenSSL/libpq runtime dependencies
- provide a .dockerignore to keep builds fast
- document image build/run instructions in README

## Testing
- docker build -t serenorg/database-replicator:latest .
